### PR TITLE
add realm settings attributes tab back

### DIFF
--- a/js/apps/admin-ui/src/phaseII/README.md
+++ b/js/apps/admin-ui/src/phaseII/README.md
@@ -11,5 +11,9 @@ P// has added a lot of additional functionality to the Admin UI. Those are cordo
   - Ensure these are listed in the `i18n.ts` file as one of the `ns` options
 - Orgs
   - This folder contains all the Orgs UI. It exists mostly independent of other code, but does import components from the `ui-shared` and the `src/components` folder.
-- Custom
+- Custom Styles
   - This folder contains all the Custom Styles UI. It exists mostly independent of other code, but does import components from the `ui-shared` and the `src/components` folder.
+- Realm Settings Attributes Tab
+  - A tab to allow setting and configuring the realm settings.
+  - Needs to be imported and added as a tab in `../realm-settings/RealmSettingsTabs.tsx`
+  - Add `attributes` as a tab option to the type def in `../realm-settings/routes/RealmSettings.tsx`

--- a/js/apps/admin-ui/src/phaseII/realm-settings/RealmSettingsAttributesTab.tsx
+++ b/js/apps/admin-ui/src/phaseII/realm-settings/RealmSettingsAttributesTab.tsx
@@ -1,0 +1,97 @@
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useForm } from "react-hook-form";
+import {
+  Alert,
+  AlertVariant,
+  PageSection,
+  PageSectionVariants,
+} from "@patternfly/react-core";
+
+import { useAlerts } from "../../components/alert/Alerts";
+import {
+  AttributeForm,
+  AttributesForm,
+} from "../../components/key-value-form-custom/AttributeForm";
+import { useAdminClient } from "../../context/auth/AdminClient";
+import RealmRepresentation from "@keycloak/keycloak-admin-client/lib/defs/realmRepresentation";
+
+type RealmSettingsAttributeTabProps = {
+  realm: RealmRepresentation;
+};
+
+export const RealmSettingsAttributeTab = ({
+  realm: defaultRealm,
+}: RealmSettingsAttributeTabProps) => {
+  const { t } = useTranslation("realm-settings");
+  const { adminClient } = useAdminClient();
+  const { addAlert, addError } = useAlerts();
+  const [realm, setRealm] = useState<RealmRepresentation>(defaultRealm);
+  const form = useForm<AttributeForm>({ mode: "onChange" });
+
+  const convertAttributes = () => {
+    const attributes: { key: string; value: string }[] = Object.entries(
+      realm.attributes || {}
+    ).flatMap(([key, value]) => ({ key, value }));
+
+    return attributes
+      .filter((a) => a.key.startsWith("_providerConfig"))
+      .sort((a, b) => {
+        const keyA = a.key.toLowerCase();
+        const keyB = b.key.toLowerCase();
+        if (keyA < keyB) return -1;
+        if (keyA > keyB) return 1;
+        return 0;
+      });
+  };
+
+  useEffect(() => {
+    form.setValue("attributes", convertAttributes());
+  }, [realm]);
+
+  const save = async (attributeForm: AttributeForm) => {
+    const attributes: Record<string, string> = {};
+    attributeForm.attributes!.map(
+      ({ key, value }) => (attributes[key] = value)
+    );
+
+    try {
+      await adminClient.realms.update(
+        { realm: realm.realm! },
+        { ...realm, attributes }
+      );
+
+      setRealm({ ...realm, attributes });
+      addAlert(t("saveSuccess"), AlertVariant.success);
+    } catch (error) {
+      addError("groups:groupUpdateError", error);
+    }
+  };
+
+  return (
+    <PageSection variant={PageSectionVariants.light}>
+      <Alert
+        variant="danger"
+        title="Expert mode customization for Phase Two extensions."
+        className="pf-u-mb-lg pf-u-w-75-on-md"
+      >
+        <p>
+          This may override configuration changes elsewhere and cause unexpected
+          behavior. Use this only if you are sure what you are doing.
+        </p>
+      </Alert>
+      <div className="pf-u-mb-lg pf-u-w-75-on-md">
+        <AttributesForm
+          form={form}
+          save={save}
+          reset={() =>
+            form.reset({
+              attributes: convertAttributes(),
+            })
+          }
+          allowFullClear
+        />
+      </div>
+    </PageSection>
+  );
+};

--- a/js/apps/admin-ui/src/realm-settings/RealmSettingsTabs.tsx
+++ b/js/apps/admin-ui/src/realm-settings/RealmSettingsTabs.tsx
@@ -49,6 +49,7 @@ import { RealmSettingsTokensTab } from "./TokensTab";
 import { UserProfileTab } from "./user-profile/UserProfileTab";
 import { UserRegistration } from "./UserRegistration";
 import { useServerInfo } from "../context/server-info/ServerInfoProvider";
+import { RealmSettingsAttributeTab } from "../phaseII/realm-settings/RealmSettingsAttributesTab";
 
 type RealmSettingsHeaderProps = {
   onChange: (value: boolean) => void;
@@ -241,6 +242,7 @@ export const RealmSettingsTabs = ({
     useServerInfo().profileInfo?.disabledFeatures?.includes("CLIENT_POLICIES");
   const userProfileTab = useTab("user-profile");
   const userRegistrationTab = useTab("user-registration");
+  const attributesTab = useTab("attributes");
 
   const useClientPoliciesTab = (tab: ClientPoliciesTab) =>
     useRoutableTab(
@@ -352,6 +354,13 @@ export const RealmSettingsTabs = ({
             {...tokensTab}
           >
             <RealmSettingsTokensTab save={save} realm={realm} />
+          </Tab>
+          <Tab
+            title={<TabTitleText>{t("attributes")}</TabTitleText>}
+            data-testid="rs-realm-attributes-tab"
+            {...attributesTab}
+          >
+            <RealmSettingsAttributeTab realm={realm} />
           </Tab>
           {!clientPoliciesDisabled && (
             <Tab

--- a/js/apps/admin-ui/src/realm-settings/routes/RealmSettings.tsx
+++ b/js/apps/admin-ui/src/realm-settings/routes/RealmSettings.tsx
@@ -16,7 +16,8 @@ export type RealmSettingsTab =
   | "tokens"
   | "client-policies"
   | "user-profile"
-  | "user-registration";
+  | "user-registration"
+  | "attributes";
 
 export type RealmSettingsParams = {
   realm: string;


### PR DESCRIPTION
- add tab back
- normalizes the data structure (helper functions changed)
- moves the tab into the `phaseII` folder to keep sectioned off