### PR TITLE
23 0 1 orgs admin UI/idp org tab

### DIFF
--- a/js/apps/admin-ui/maven-resources/theme/phasetwo.v2/admin/messages/messages_en.properties
+++ b/js/apps/admin-ui/maven-resources/theme/phasetwo.v2/admin/messages/messages_en.properties
@@ -3031,3 +3031,7 @@ noIDPsAvailable=No IdPs are available to assign to this Org. Add an Identity Pro
 noIDPAssigned=No Identity Providers are assigned to this Organization. Assign an Identity Provider to be able to use it with this Organization.
 idpAssignedToOrg=Identity Provider assigned to Organization
 idpChangeHelpText=Change the active IdP for this Organization.
+idpAssign=Assign Identity Provider
+assignIdentityProviderTo=Assign Identity Provider to
+idpAssignedToOrg=Assigned to this Org
+assignNewIdp=Assign new identity provider to this organization

--- a/js/apps/admin-ui/src/environment.ts
+++ b/js/apps/admin-ui/src/environment.ts
@@ -28,8 +28,8 @@ const realm = new URLSearchParams(window.location.search).get("realm");
 const defaultEnvironment: Environment = {
   loginRealm: realm ?? "master",
   clientId: "security-admin-console-v2",
-  authServerUrl: "http://localhost:8180",
-  authUrl: "http://localhost:8180",
+  authServerUrl: "https://app-staging.phasetwo.io/auth",
+  authUrl: "https://app-staging.phasetwo.io/auth",
   consoleBaseUrl: "/admin/master/console/",
   resourceUrl: ".",
   masterRealm: "master",

--- a/js/apps/admin-ui/src/environment.ts
+++ b/js/apps/admin-ui/src/environment.ts
@@ -28,8 +28,8 @@ const realm = new URLSearchParams(window.location.search).get("realm");
 const defaultEnvironment: Environment = {
   loginRealm: realm ?? "master",
   clientId: "security-admin-console-v2",
-  authServerUrl: "https://app-staging.phasetwo.io/auth",
-  authUrl: "https://app-staging.phasetwo.io/auth",
+  authServerUrl: "http://localhost:8180",
+  authUrl: "http://localhost:8180",
   consoleBaseUrl: "/admin/master/console/",
   resourceUrl: ".",
   masterRealm: "master",

--- a/js/apps/admin-ui/src/phaseII/orgs/AddMember.tsx
+++ b/js/apps/admin-ui/src/phaseII/orgs/AddMember.tsx
@@ -16,7 +16,7 @@ import { ListEmptyState } from "../../components/list-empty-state/ListEmptyState
 import { emptyFormatter } from "../../util";
 import { toAddUser } from "../../user/routes/AddUser";
 import useOrgFetcher from "./useOrgFetcher";
-import { differenceBy } from "lodash";
+import { differenceBy } from "lodash-es";
 import { adminClient } from "../../admin-client";
 
 type MemberModalProps = {

--- a/js/apps/admin-ui/src/phaseII/orgs/modals/AssignIdentityProvider.tsx
+++ b/js/apps/admin-ui/src/phaseII/orgs/modals/AssignIdentityProvider.tsx
@@ -1,0 +1,314 @@
+import { useTranslation } from "react-i18next";
+import { useEffect, useMemo, useState } from "react";
+import {
+  Button,
+  ButtonVariant,
+  Form,
+  Modal,
+  ModalVariant,
+  PageSection,
+  Radio,
+  FormGroup,
+  FormSelect,
+  FormSelectOption,
+  AlertGroup,
+  Alert,
+  AlertVariant,
+} from "@patternfly/react-core";
+import { PaginatingTableToolbar } from "../../../components/table-toolbar/PaginatingTableToolbar";
+import IdentityProviderRepresentation from "../../../../../../libs/keycloak-admin-client/lib/defs/identityProviderRepresentation";
+import useLocaleSort, { mapByKey } from "../../../utils/useLocaleSort";
+import { useFetch } from "../../../utils/useFetch";
+import { AlertInfo, SyncMode, idpRep } from "../OrgIdentityProviders";
+import useOrgFetcher from "../useOrgFetcher";
+import { useRealm } from "../../../context/realm-context/RealmContext";
+import { OrgRepresentation } from "../routes";
+import { Controller, FormProvider, useForm } from "react-hook-form";
+import { AuthenticationType } from "../../../authentication/AuthenticationSection";
+import { fetchWithError } from "../../../../../../libs/keycloak-admin-client/lib/utils/fetchWithError";
+import { addTrailingSlash } from "../../../util";
+import { adminClient } from "../../../admin-client";
+import { getAuthorizationHeaders } from "../../../utils/getAuthorizationHeaders";
+
+type IdentityProviderListProps = {
+  list?: IdentityProviderRepresentation[];
+  setValue: (provider?: IdentityProviderRepresentation) => void;
+  org: OrgRepresentation;
+};
+
+const syncModeOptions = [
+  { value: null, label: "Select one", disabled: false },
+  { value: "FORCE", label: "FORCE", disabled: false },
+  { value: "LEGACY", label: "LEGACY", disabled: false },
+  { value: "IMPORT", label: "IMPORT", disabled: false },
+];
+
+const IdentityProviderList = ({
+  list,
+  setValue,
+  org,
+}: IdentityProviderListProps) => {
+  console.log("🚀 ~ list:", list);
+  const { t } = useTranslation();
+  return (
+    <PageSection variant="light" className="pf-u-py-lg">
+      <Form isHorizontal>
+        {list?.map((identityProvider) => {
+          const idpAssignedToThisOrg =
+            identityProvider.config?.["home.idp.discovery.org"] === org.id;
+
+          return (
+            <Radio
+              id={identityProvider.internalId!}
+              key={identityProvider.internalId}
+              name="identityProvider"
+              label={`${identityProvider.displayName} ${
+                identityProvider.enabled ? "(enabled)" : ""
+              } ${idpAssignedToThisOrg ? `[${t("idpAssignedToOrg")}]` : ""}`}
+              data-testid={identityProvider.internalId}
+              description={identityProvider.alias}
+              onChange={() => {
+                setValue(identityProvider);
+              }}
+              isDisabled={idpAssignedToThisOrg}
+              title={idpAssignedToThisOrg ? t("idpAssignedToOrg") : ""}
+            />
+          );
+        })}
+      </Form>
+    </PageSection>
+  );
+};
+
+type AssignIdentityProviderProps = {
+  onSelect: (
+    identityProvider: IdentityProviderRepresentation,
+    idpConfig: idpFormValues,
+  ) => void;
+  onClear: () => void;
+  organization: OrgRepresentation;
+  alerts: AlertInfo[];
+};
+
+type idpFormValues = {
+  postBrokerLoginFlowAlias: IdentityProviderRepresentation["postBrokerLoginFlowAlias"];
+  syncMode: SyncMode;
+};
+
+export function AssignIdentityProvider({
+  onSelect,
+  onClear,
+  organization,
+  alerts,
+}: AssignIdentityProviderProps) {
+  const { t } = useTranslation();
+  const { realm } = useRealm();
+  const { getIdpsForRealm } = useOrgFetcher(realm);
+
+  const [value, setValue] = useState<IdentityProviderRepresentation>();
+  const [identityProviders, setIdentityProviders] =
+    useState<IdentityProviderRepresentation[]>();
+  const [max, setMax] = useState(10);
+  const [first, setFirst] = useState(0);
+  const [search, setSearch] = useState("");
+  const localeSort = useLocaleSort();
+  const [authFlowOptions, setAuthFlowOptions] = useState<
+    { label: string; value: string }[]
+  >([]);
+
+  const idpSelectionForm = useForm<idpFormValues>({
+    defaultValues: {
+      postBrokerLoginFlowAlias: "post org broker login",
+      syncMode: "FORCE",
+    },
+  });
+
+  const {
+    control,
+    setValue: setFormValue,
+    getValues: getFormValues,
+  } = idpSelectionForm;
+
+  useEffect(() => {
+    setFormValue("postBrokerLoginFlowAlias", value?.postBrokerLoginFlowAlias);
+    //@ts-ignore
+    setFormValue("syncMode", value?.config?.syncMode);
+  }, [value]);
+
+  async function getAuthFlowOptions() {
+    const flowsRequest = await fetchWithError(
+      `${addTrailingSlash(
+        adminClient.baseUrl,
+      )}admin/realms/${realm}/ui-ext/authentication-management/flows`,
+      {
+        method: "GET",
+        headers: getAuthorizationHeaders(await adminClient.getAccessToken()),
+      },
+    );
+    const flows = await flowsRequest.json();
+
+    if (!flows) {
+      return;
+    }
+
+    setAuthFlowOptions(
+      flows.map((flow: AuthenticationType) => ({
+        value: flow.alias,
+        label: flow.alias,
+      })),
+    );
+  }
+
+  useEffect(() => {
+    getAuthFlowOptions();
+  }, []);
+
+  const page = useMemo(() => {
+    const normalizedSearch = search.trim().toLowerCase();
+    return localeSort(identityProviders ?? [], mapByKey("displayName"))
+      .filter(
+        ({ displayName }) =>
+          displayName?.toLowerCase().includes(normalizedSearch),
+      )
+      .slice(first, first + max + 1);
+  }, [identityProviders, search, first, max]);
+
+  useFetch(
+    async () => {
+      const args: { first: number; max: number; search?: string } = {
+        first,
+        max,
+        search: search || undefined,
+      };
+      return (await getIdpsForRealm(args)) as idpRep[];
+    },
+    (identityProviders) => {
+      setIdentityProviders(identityProviders);
+    },
+    [search],
+  );
+
+  return (
+    <Modal
+      variant={ModalVariant.medium}
+      isOpen={true}
+      title={t("assignIdentityProviderTo", { organization })}
+      onClose={() => onClear()}
+      actions={[
+        <Button
+          id="modal-add"
+          data-testid="modal-add"
+          key="add"
+          isDisabled={!value}
+          onClick={() => onSelect(value!, getFormValues() as idpFormValues)}
+        >
+          {t("assign")}
+        </Button>,
+        <Button
+          data-testid="cancel"
+          id="modal-cancel"
+          key="cancel"
+          variant={ButtonVariant.link}
+          onClick={() => {
+            onClear();
+          }}
+        >
+          {t("cancel")}
+        </Button>,
+      ]}
+    >
+      <AlertGroup
+        isLiveRegion
+        aria-live="polite"
+        aria-relevant="additions text"
+        aria-atomic="false"
+      >
+        {alerts
+          .filter(({ variant }) => variant === AlertVariant.danger)
+          .map(({ title, variant, key }) => (
+            <Alert
+              variant={variant}
+              title={title}
+              key={key}
+              timeout={8000}
+              className="pf-u-mb-lg"
+            />
+          ))}
+      </AlertGroup>
+      {identityProviders && (
+        <PaginatingTableToolbar
+          count={page.length || 0}
+          first={first}
+          max={max}
+          onNextClick={setFirst}
+          onPreviousClick={setFirst}
+          onPerPageSelect={(first, max) => {
+            setFirst(first);
+            setMax(max);
+          }}
+          inputGroupName="search"
+          inputGroupPlaceholder={t("search")}
+          inputGroupOnEnter={setSearch}
+        >
+          <IdentityProviderList
+            list={page.slice(0, max)}
+            setValue={setValue}
+            org={organization}
+          />
+        </PaginatingTableToolbar>
+      )}
+      <FormProvider {...idpSelectionForm}>
+        <Form>
+          <FormGroup
+            label="Post Broker Login"
+            fieldId="postBrokerLoginFlowAlias"
+          >
+            <Controller
+              name="postBrokerLoginFlowAlias"
+              control={control}
+              render={({ field }) => (
+                <FormSelect
+                  value={field.value}
+                  onChange={field.onChange}
+                  aria-label="Post Broker Login Flow Alias Input"
+                  ouiaId="Post Broker Login Flow Alias Input"
+                >
+                  {authFlowOptions.map((option, index) => (
+                    <FormSelectOption
+                      key={index}
+                      value={option.value}
+                      label={option.label}
+                    />
+                  ))}
+                </FormSelect>
+              )}
+            />
+          </FormGroup>
+          <FormGroup label="Sync Mode" fieldId="syncMode">
+            <Controller
+              name="syncMode"
+              control={control}
+              render={({ field }) => (
+                <FormSelect
+                  value={field.value}
+                  onChange={field.onChange}
+                  aria-label="SyncMode Input"
+                  ouiaId="SyncMode Input"
+                >
+                  {syncModeOptions.map((option, index) => (
+                    <FormSelectOption
+                      isDisabled={option.disabled}
+                      key={index}
+                      value={option.value}
+                      label={option.label}
+                    />
+                  ))}
+                </FormSelect>
+              )}
+            />
+          </FormGroup>
+        </Form>
+      </FormProvider>
+    </Modal>
+  );
+}

--- a/js/apps/admin-ui/src/phaseII/orgs/modals/AssignRoleToMemberInOrgModal.tsx
+++ b/js/apps/admin-ui/src/phaseII/orgs/modals/AssignRoleToMemberInOrgModal.tsx
@@ -12,7 +12,7 @@ import { useRealm } from "../../../context/realm-context/RealmContext";
 import type UserRepresentation from "@keycloak/keycloak-admin-client/lib/defs/userRepresentation";
 import type RoleRepresentation from "@keycloak/keycloak-admin-client/lib/defs/roleRepresentation";
 import { KeycloakDataTableCustomized } from "../components/KeycloakDataTableCustomized";
-import { differenceBy } from "lodash";
+import { differenceBy } from "lodash-es";
 
 type AssignRoleToMemberProps = {
   orgId: string;

--- a/js/apps/admin-ui/src/phaseII/orgs/useOrgFetcher.ts
+++ b/js/apps/admin-ui/src/phaseII/orgs/useOrgFetcher.ts
@@ -21,6 +21,7 @@ export default function useOrgFetcher(realm: string) {
 
   const authUrl = environment.authServerUrl;
   const baseUrl = `${authUrl}/realms/${realm}`;
+  const adminUrl = `${authUrl}/admin/realms/${realm}`;
 
   async function fetchGet(url: string) {
     const token = await adminClient.getAccessToken();
@@ -414,9 +415,42 @@ export default function useOrgFetcher(realm: string) {
     }
   }
 
+  // GET /:realm/identity-provider/instances
   async function getIdpsForOrg(orgId: OrgRepresentation["id"]) {
     try {
       const resp = await fetchGet(`${baseUrl}/orgs/${orgId}/idps`);
+      if (resp.ok) {
+        return (await resp.json()) as IdentityProviderRepresentation[];
+      }
+      return {
+        error: true,
+        message: "Failed to fetch IDPs for org.",
+      };
+    } catch (error) {
+      return {
+        error: true,
+        message: error,
+      };
+    }
+  }
+
+  async function getIdpsForRealm({
+    first = 0,
+    max = 100,
+    search,
+  }: {
+    first: number;
+    max: number;
+    search?: string;
+  }) {
+    try {
+      let query = `first=${first}&max=${max}`;
+      if (search && search.length > 0) {
+        query = `${query}&search=${search}`;
+      }
+      const resp = await fetchGet(
+        `${adminUrl}/identity-provider/instances?${query}`,
+      );
       if (resp.ok) {
         return (await resp.json()) as IdentityProviderRepresentation[];
       }
@@ -480,6 +514,7 @@ export default function useOrgFetcher(realm: string) {
     deleteOrgInvitation,
     deleteRoleFromOrg,
     getIdpsForOrg,
+    getIdpsForRealm,
     getOrg,
     getOrgInvitations,
     getOrgMembers,

--- a/js/apps/admin-ui/src/phaseII/orgs/useOrgFetcher.ts
+++ b/js/apps/admin-ui/src/phaseII/orgs/useOrgFetcher.ts
@@ -414,6 +414,24 @@ export default function useOrgFetcher(realm: string) {
     }
   }
 
+  async function getIdpsForOrg(orgId: OrgRepresentation["id"]) {
+    try {
+      const resp = await fetchGet(`${baseUrl}/orgs/${orgId}/idps`);
+      if (resp.ok) {
+        return (await resp.json()) as IdentityProviderRepresentation[];
+      }
+      return {
+        error: true,
+        message: "Failed to fetch IDPs for org.",
+      };
+    } catch (error) {
+      return {
+        error: true,
+        message: error,
+      };
+    }
+  }
+
   // POST /:realm/orgs/:orgId/idps/link
   async function linkIDPtoOrg(
     orgId: OrgRepresentation["id"],
@@ -461,6 +479,7 @@ export default function useOrgFetcher(realm: string) {
     deleteOrg,
     deleteOrgInvitation,
     deleteRoleFromOrg,
+    getIdpsForOrg,
     getOrg,
     getOrgInvitations,
     getOrgMembers,

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -7841,6 +7841,7 @@ packages:
       i18next: 23.7.6
       i18next-http-backend: 2.4.2
       keycloak-js: link:libs/keycloak-js
+      lodash: 4.17.21
       lodash-es: 4.17.21
       monaco-editor: 0.44.0
       react: 18.2.0


### PR DESCRIPTION
In a modal
- Search for an IDP, paginate for an IDP
- Radio button select
- Updates values for post broker and sync for that IDP
- Can still override those items
- IDP for current assigned org is disabled
- Enabled ones show up with text as enabled already (doesn't indicate to which)

<img width="871" alt="image" src="https://github.com/p2-inc/keycloak/assets/93841792/769e0133-15c2-4164-8dea-f48ab9100ee6">
<img width="1013" alt="image" src="https://github.com/p2-inc/keycloak/assets/93841792/3ae7a21f-5c30-46fe-8d17-09e17b563411">


There are translation values, but not point to a local build for those to exist. 