### PR TITLE
Fix empty domain handling in org creation and IdP assignment

### DIFF
--- a/js/apps/admin-ui/src/phaseII/orgs/modals/EditIdentityProviderHomeIdpDomains.tsx
+++ b/js/apps/admin-ui/src/phaseII/orgs/modals/EditIdentityProviderHomeIdpDomains.tsx
@@ -43,8 +43,7 @@ export default function EditIdentityProviderHomeIdpDomains({
     },
   });
 
-  const { control, handleSubmit, watch, reset } = form;
-  const selectedDomains = watch("homeIdpDomains");
+  const { control, handleSubmit, reset } = form;
 
   // Reset form when idp changes
   useEffect(() => {
@@ -58,7 +57,7 @@ export default function EditIdentityProviderHomeIdpDomains({
   }, [idp, reset]);
 
   async function handleConfirm() {
-    handleSubmit(async (data) => {
+    await handleSubmit(async (data) => {
       if (!idp) return;
 
       try {
@@ -120,36 +119,42 @@ export default function EditIdentityProviderHomeIdpDomains({
             <Controller
               name="homeIdpDomains"
               control={control}
-              render={({ field }) => (
-                <div>
-                  {org.domains?.map((domain) => (
-                    <Checkbox
-                      key={domain}
-                      id={`domain-${domain}`}
-                      label={domain}
-                      isChecked={field.value.includes(domain)}
-                      className="pf-v5-u-mt-sm"
-                      onChange={(event, checked) => {
-                        const currentValues = field.value || [];
-                        if (checked) {
-                          // Add domain if not already selected
-                          if (!currentValues.includes(domain)) {
-                            field.onChange([...currentValues, domain]);
-                          }
-                        } else {
-                          // Remove domain if currently selected
-                          field.onChange(
-                            currentValues.filter((d) => d !== domain),
-                          );
-                        }
-                      }}
-                    />
-                  ))}
-                  {(!org.domains || org.domains.length === 0) && (
-                    <div>{t("orgNoDomainsAvailable")}</div>
-                  )}
-                </div>
-              )}
+              render={({ field }) => {
+                const validDomains =
+                  org.domains?.filter((domain) => domain.trim() !== "") || [];
+
+                return (
+                  <div>
+                    {validDomains.length > 0 ? (
+                      validDomains.map((domain) => (
+                        <Checkbox
+                          key={domain}
+                          id={`domain-${domain}`}
+                          label={domain}
+                          isChecked={field.value.includes(domain)}
+                          className="pf-v5-u-mt-sm"
+                          onChange={(event, checked) => {
+                            const currentValues = field.value || [];
+                            if (checked) {
+                              // Add domain if not already selected
+                              if (!currentValues.includes(domain)) {
+                                field.onChange([...currentValues, domain]);
+                              }
+                            } else {
+                              // Remove domain if currently selected
+                              field.onChange(
+                                currentValues.filter((d) => d !== domain),
+                              );
+                            }
+                          }}
+                        />
+                      ))
+                    ) : (
+                      <div>{t("orgNoDomainsAvailable")}</div>
+                    )}
+                  </div>
+                );
+              }}
             />
             <FormHelperText className="pf-v5-u-mt-lg">
               {t("orgIdpAssignedDomainsHelperText")}

--- a/js/apps/admin-ui/src/phaseII/orgs/modals/NewOrgModal.tsx
+++ b/js/apps/admin-ui/src/phaseII/orgs/modals/NewOrgModal.tsx
@@ -51,7 +51,12 @@ export const NewOrgModal = ({
 
   const submitForm = async (org: OrgFormType) => {
     try {
-      const res = await createOrg(org);
+      const cleanedOrg = {
+        ...org,
+        domains: org.domains.filter((domain) => domain.trim() !== ""),
+      };
+
+      const res = await createOrg(cleanedOrg);
 
       if (res.success) {
         addAlert(t("orgCreated"), AlertVariant.success);


### PR DESCRIPTION
Fixes two related bugs with organization domain handling in the Admin UI.
Issue: https://github.com/p2-inc/keycloak-orgs/issues/402

### Changes

**1. Org Creation - Filter empty domains (`NewOrgModal.tsx`)**

When creating an organization without specifying any domains, the form was sending `[""]` to the API instead of `[]`. Added filtering to remove empty strings before submission.

**2. IdP Domain Assignment - Hide empty domains (`EditIdentityProviderHomeIdpDomains.tsx`)**

When an organization had an empty domain string (`""`), the IdP domain assignment modal displayed an empty checkbox. Now filters out empty domains and shows "no domains available" message when appropriate.