### PR TITLE
Admin UI improvements for Phase Two extensions.

### DIFF
--- a/js/apps/admin-ui/src/phaseII/custom-styles/login/login-styles.tsx
+++ b/js/apps/admin-ui/src/phaseII/custom-styles/login/login-styles.tsx
@@ -1,4 +1,5 @@
 import {
+  Alert,
   AlertVariant,
   Flex,
   FlexItem,
@@ -85,7 +86,7 @@ export const LoginStyles = ({ refresh, realm }: LoginStylesArgs) => {
   }
 
   useEffect(() => {
-    loadRealm();
+    void loadRealm();
   }, []);
 
   const addOrRemoveItem = (
@@ -164,6 +165,17 @@ export const LoginStyles = ({ refresh, realm }: LoginStylesArgs) => {
 
   return (
     <PageSection variant="light" className="keycloak__form">
+      <Alert
+        variant="info"
+        title="Theme activation required"
+        isInline
+        className="pf-v5-u-mb-lg"
+      >
+        <p>
+          Ensure that the <code>attributes.v2</code> theme is enabled in order
+          to see these take effect.
+        </p>
+      </Alert>
       <Form isHorizontal>
         <FormProvider {...form}>
           {/* Primary Color */}

--- a/js/apps/admin-ui/src/phaseII/custom-styles/portal/portal-styles.tsx
+++ b/js/apps/admin-ui/src/phaseII/custom-styles/portal/portal-styles.tsx
@@ -1,10 +1,13 @@
 import {
+  Alert,
   AlertVariant,
   Checkbox,
   Form,
   PageSection,
   Title,
 } from "@patternfly/react-core";
+import { FormattedLink } from "../../../components/external-link/FormattedLink";
+import helpUrls from "../../../help-urls";
 import { Controller, FormProvider, useForm, useWatch } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { HelpItem, TextAreaControl } from "@keycloak/keycloak-ui-shared";
@@ -153,7 +156,7 @@ export const PortalStyles = ({ refresh, realm }: PortalStylesArgs) => {
   }
 
   useEffect(() => {
-    loadRealm();
+    void loadRealm();
   }, []);
 
   const addOrRemoveItem = (
@@ -278,6 +281,23 @@ export const PortalStyles = ({ refresh, realm }: PortalStylesArgs) => {
 
   return (
     <PageSection variant="light" className="keycloak__form portal-styles">
+      <Alert
+        variant="info"
+        title="Admin Portal"
+        isInline
+        className="pf-v5-u-mb-lg"
+      >
+        <p>
+          Learn more about how the Admin Portal works and how to customize it.
+          Launch the &quot;admin portal&quot; client from the client list to see
+          the portal in action.{" "}
+          <FormattedLink
+            title={t("learnMore")}
+            href={helpUrls.adminPortalUrl}
+            isInline
+          />
+        </p>
+      </Alert>
       <Form isHorizontal>
         <FormProvider {...form}>
           <Title headingLevel="h3" className="pf-c-title pf-m-xl">

--- a/js/apps/admin-ui/src/phaseII/help-urls.ts
+++ b/js/apps/admin-ui/src/phaseII/help-urls.ts
@@ -3,4 +3,13 @@ const phasetwoDocs = "https://phasetwo.io/docs";
 export const PhaseTwoHelpUrls = {
   orgsUrl: `${phasetwoDocs}/organizations/`,
   stylesUrl: `${phasetwoDocs}/getting-started/customizing-ui`,
+  realmAttributesUrl: `${phasetwoDocs}/api/realm-attributes`,
+  orgDomainsUrl: `${phasetwoDocs}/organizations/identity-providers/#verified-domains`,
+  orgAttributesUrl: `${phasetwoDocs}/organizations/attributes/`,
+  orgMembersUrl: `${phasetwoDocs}/organizations/membership/`,
+  orgInvitationsUrl: `${phasetwoDocs}/organizations/invitations/`,
+  orgRolesUrl: `${phasetwoDocs}/organizations/roles/`,
+  orgIdpsUrl: `${phasetwoDocs}/organizations/identity-providers/`,
+  adminPortalUrl: `${phasetwoDocs}/admin-portal/`,
+  idpWizardUrl: `${phasetwoDocs}/organizations/idp-wizard/`,
 };

--- a/js/apps/admin-ui/src/phaseII/orgs/OrgAttributes.tsx
+++ b/js/apps/admin-ui/src/phaseII/orgs/OrgAttributes.tsx
@@ -14,6 +14,9 @@ import useOrgFetcher from "./useOrgFetcher";
 import { useRealm } from "../../context/realm-context/RealmContext";
 import { useAlerts } from "@keycloak/keycloak-ui-shared";
 import { CardBody, Card } from "@patternfly/react-core";
+import { FormattedLink } from "../../components/external-link/FormattedLink";
+import helpUrls from "../../help-urls";
+import { useTranslation } from "react-i18next";
 
 type OrgAttributesProps = {
   org: OrgRepresentation;
@@ -25,6 +28,7 @@ type AttributesForm = {
 };
 
 export default function OrgAttributes({ org, refresh }: OrgAttributesProps) {
+  const { t } = useTranslation();
   const { addAlert } = useAlerts();
   const { realm } = useRealm();
   const { updateOrg } = useOrgFetcher(realm);
@@ -61,6 +65,13 @@ export default function OrgAttributes({ org, refresh }: OrgAttributesProps) {
 
   return (
     <div className="pf-v5-u-pt-lg">
+      <div className="pf-v5-u-mb-md pf-v5-u-px-lg">
+        <FormattedLink
+          title={t("learnMore")}
+          href={helpUrls.orgAttributesUrl}
+          isInline
+        />
+      </div>
       <Card isFlat>
         <CardBody>
           <AttributesForm

--- a/js/apps/admin-ui/src/phaseII/orgs/OrgDetails.tsx
+++ b/js/apps/admin-ui/src/phaseII/orgs/OrgDetails.tsx
@@ -1,10 +1,5 @@
 import { useEffect, useState } from "react";
-import {
-  PageSection,
-  Tab,
-  TabTitleText,
-  DropdownItem,
-} from "@patternfly/react-core";
+import { Button, PageSection, Tab, TabTitleText } from "@patternfly/react-core";
 import { useTranslation } from "react-i18next";
 import { useParams } from "react-router-dom";
 import { useRealm } from "../../context/realm-context/RealmContext";
@@ -20,6 +15,7 @@ import { PortalLink } from "./components/portal-link/PortalLink";
 import useToggle from "../../utils/useToggle";
 import OrgIdentityProviders from "./OrgIdentityProviders";
 import OrgSettings from "./OrgSettings";
+import OrgDomains from "./OrgDomains";
 import OrgAttributes from "./OrgAttributes";
 import {
   RoutableTabs,
@@ -55,6 +51,7 @@ export default function OrgDetails() {
     );
 
   const settingsTab = useTab("settings");
+  const domainsTab = useTab("domains");
   const attributesTab = useTab("attributes");
   const membersTab = useTab("members");
   const invitationsTab = useTab("invitations");
@@ -63,19 +60,22 @@ export default function OrgDetails() {
 
   if (!org) return <div></div>;
 
-  const dropdownItems = [
-    <DropdownItem key="download" onClick={togglePortalLinkOpen}>
-      {t("generatePortalLink")}
-    </DropdownItem>,
-  ];
-
   return (
     <>
       <ViewHeader
         titleKey={org.displayName || org.name || org.id}
         divider={false}
-        dropdownItems={dropdownItems}
       />
+      <PageSection variant="light" className="pf-v5-u-pt-0 pf-v5-u-pb-md">
+        <Button
+          variant="secondary"
+          size="sm"
+          onClick={togglePortalLinkOpen}
+          data-testid="generate-portal-link-btn"
+        >
+          {t("generatePortalLink")}
+        </Button>
+      </PageSection>
       <PortalLink
         id="id"
         open={portalLinkOpen}
@@ -89,6 +89,13 @@ export default function OrgDetails() {
             {...settingsTab}
           >
             <OrgSettings org={org} refresh={refresh} />
+          </Tab>
+          <Tab
+            id="domains"
+            title={<TabTitleText>Domains</TabTitleText>}
+            {...domainsTab}
+          >
+            <OrgDomains org={org} refresh={refresh} />
           </Tab>
           <Tab
             id="attributes"

--- a/js/apps/admin-ui/src/phaseII/orgs/OrgDomains.tsx
+++ b/js/apps/admin-ui/src/phaseII/orgs/OrgDomains.tsx
@@ -1,0 +1,146 @@
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  AlertVariant,
+  Button,
+  ClipboardCopy,
+  Label,
+  PageSection,
+  TextContent,
+  Text,
+  Title,
+} from "@patternfly/react-core";
+import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
+import { CheckCircleIcon } from "@patternfly/react-icons";
+import { useRealm } from "../../context/realm-context/RealmContext";
+import { useAlerts } from "@keycloak/keycloak-ui-shared";
+import { FormattedLink } from "../../components/external-link/FormattedLink";
+import helpUrls from "../../help-urls";
+import useOrgFetcher, {
+  OrganizationDomainRepresentation,
+} from "./useOrgFetcher";
+import type { OrgRepresentation } from "./routes";
+
+type OrgDomainsProps = {
+  org: OrgRepresentation;
+  refresh: () => void;
+};
+
+export default function OrgDomains({ org, refresh }: OrgDomainsProps) {
+  const { t } = useTranslation();
+  const { realm } = useRealm();
+  const { getOrgDomains, verifyDomain } = useOrgFetcher(realm);
+  const { addAlert } = useAlerts();
+  const [domains, setDomains] = useState<OrganizationDomainRepresentation[]>(
+    [],
+  );
+  const [loading, setLoading] = useState(true);
+
+  const fetchDomains = async () => {
+    try {
+      const data = await getOrgDomains(org.id);
+      setDomains(data);
+    } catch (e) {
+      console.error("Error fetching domains", e);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void fetchDomains();
+  }, [org]);
+
+  const handleVerify = async (domainName: string) => {
+    const result = await verifyDomain(org.id, domainName);
+    if (result.success) {
+      addAlert("Domain verification triggered.", AlertVariant.success);
+      await fetchDomains();
+      refresh();
+    } else {
+      addAlert(
+        `Domain verification failed. ${result.message}`,
+        AlertVariant.danger,
+      );
+    }
+  };
+
+  if (loading) {
+    return null;
+  }
+
+  return (
+    <PageSection variant="light">
+      <Title headingLevel="h2" size="lg" className="pf-v5-u-mb-sm">
+        Domains
+      </Title>
+      <TextContent className="pf-v5-u-mb-lg">
+        <Text>
+          View linked domains and verify dns entries.{" "}
+          <FormattedLink
+            title={t("learnMore")}
+            href={helpUrls.orgDomainsUrl}
+            isInline
+          />
+        </Text>
+      </TextContent>
+      {domains.length === 0 ? (
+        <TextContent>
+          <Text>
+            No domains linked to this organization. Add domains in the Settings
+            tab.
+          </Text>
+        </TextContent>
+      ) : (
+        <Table variant="compact" borders>
+          <Thead>
+            <Tr>
+              <Th>Domain name</Th>
+              <Th>Validated</Th>
+              <Th />
+            </Tr>
+          </Thead>
+          <Tbody>
+            {domains.map((domain) => (
+              <Tr key={domain.domain_name}>
+                <Td dataLabel="Domain name">{domain.domain_name}</Td>
+                <Td dataLabel="Validated">
+                  {domain.verified ? (
+                    <Label color="green" icon={<CheckCircleIcon />}>
+                      Verified
+                    </Label>
+                  ) : (
+                    <div>
+                      <Label color="orange">Verification pending</Label>
+                      {domain.record_key && domain.record_value && (
+                        <div className="pf-v5-u-mt-sm">
+                          <Text component="small" className="pf-v5-u-mb-xs">
+                            Create a DNS TXT record for the hostname with the
+                            following value
+                          </Text>
+                          <ClipboardCopy isReadOnly variant="expansion">
+                            {`${domain.record_key}=${domain.record_value}`}
+                          </ClipboardCopy>
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </Td>
+                <Td dataLabel="Actions" className="pf-v5-u-text-align-right">
+                  {!domain.verified && (
+                    <Button
+                      variant="link"
+                      onClick={() => handleVerify(domain.domain_name)}
+                    >
+                      Verify
+                    </Button>
+                  )}
+                </Td>
+              </Tr>
+            ))}
+          </Tbody>
+        </Table>
+      )}
+    </PageSection>
+  );
+}

--- a/js/apps/admin-ui/src/phaseII/orgs/OrgIdentityProviders.tsx
+++ b/js/apps/admin-ui/src/phaseII/orgs/OrgIdentityProviders.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
-
 import { useAlerts } from "@keycloak/keycloak-ui-shared";
 import {
   AlertVariant,
@@ -23,6 +21,8 @@ import { useTranslation } from "react-i18next";
 import { Link, NavLink } from "react-router-dom";
 import IdentityProviderRepresentation from "../../../../../libs/keycloak-admin-client/lib/defs/identityProviderRepresentation";
 import { useRealm } from "../../context/realm-context/RealmContext";
+import { FormattedLink } from "../../components/external-link/FormattedLink";
+import helpUrls from "../../help-urls";
 import { toIdentityProvider } from "../../identity-providers/routes/IdentityProvider";
 import { AssignIdentityProvider } from "./modals/AssignIdentityProvider";
 import EditIdentityProviderHomeIdpDomains from "./modals/EditIdentityProviderHomeIdpDomains";
@@ -91,8 +91,8 @@ export default function OrgIdentityProviders({
   }
 
   const refreshIdPs = () => {
-    getIDPs();
-    fetchOrgIdps();
+    void getIDPs();
+    void fetchOrgIdps();
   };
 
   useEffect(() => {
@@ -280,7 +280,7 @@ export default function OrgIdentityProviders({
           {showAssignIdpModal && (
             <AssignIdentityProvider
               onSelect={(identityProvider, idpConfig) => {
-                assignIdentityProvider({
+                void assignIdentityProvider({
                   identityProvider,
                   idpConfig: {
                     ...idpConfig,
@@ -306,5 +306,16 @@ export default function OrgIdentityProviders({
     );
   }
 
-  return <div className="pf-v5-u-p-lg">{body}</div>;
+  return (
+    <div className="pf-v5-u-p-lg">
+      <div className="pf-v5-u-mb-md">
+        <FormattedLink
+          title={t("learnMore")}
+          href={helpUrls.orgIdpsUrl}
+          isInline
+        />
+      </div>
+      {body}
+    </div>
+  );
 }

--- a/js/apps/admin-ui/src/phaseII/orgs/OrgInvitations.tsx
+++ b/js/apps/admin-ui/src/phaseII/orgs/OrgInvitations.tsx
@@ -3,7 +3,9 @@ import { Action, KeycloakDataTable } from "@keycloak/keycloak-ui-shared";
 import { useRealm } from "../../context/realm-context/RealmContext";
 import type { OrgRepresentation } from "./routes";
 import useOrgFetcher from "./useOrgFetcher";
-import { Button, ToolbarItem } from "@patternfly/react-core";
+import { Button, TextContent, Text, ToolbarItem } from "@patternfly/react-core";
+import { FormattedLink } from "../../components/external-link/FormattedLink";
+import helpUrls from "../../help-urls";
 import { ListEmptyState } from "@keycloak/keycloak-ui-shared";
 import AddInvitation from "./AddInvitation";
 import { useAlerts } from "@keycloak/keycloak-ui-shared";
@@ -52,6 +54,15 @@ export default function OrgInvitations({
 
   return (
     <>
+      <TextContent className="pf-v5-u-px-lg pf-v5-u-pt-lg">
+        <Text>
+          <FormattedLink
+            title={t("learnMore")}
+            href={helpUrls.orgInvitationsUrl}
+            isInline
+          />
+        </Text>
+      </TextContent>
       {invitationModalVisibility && (
         <AddInvitation
           refresh={refresh}

--- a/js/apps/admin-ui/src/phaseII/orgs/OrgMembers.tsx
+++ b/js/apps/admin-ui/src/phaseII/orgs/OrgMembers.tsx
@@ -9,7 +9,9 @@ import type { OrgRepresentation } from "./routes";
 import useOrgFetcher, {
   PhaseTwoOrganizationUserRepresentation,
 } from "./useOrgFetcher";
-import { Button, ToolbarItem } from "@patternfly/react-core";
+import { Button, TextContent, Text, ToolbarItem } from "@patternfly/react-core";
+import { FormattedLink } from "../../components/external-link/FormattedLink";
+import helpUrls from "../../help-urls";
 import type UserRepresentation from "@keycloak/keycloak-admin-client/lib/defs/userRepresentation";
 import { Link } from "react-router-dom";
 import { toUser } from "../../user/routes/User";
@@ -58,7 +60,7 @@ export default function OrgMembers({
       setOrgRoles(data);
     };
 
-    fetchData();
+    void fetchData();
   }, []);
 
   const loader = async (
@@ -74,6 +76,15 @@ export default function OrgMembers({
 
   return (
     <>
+      <TextContent className="pf-v5-u-px-lg pf-v5-u-pt-lg">
+        <Text>
+          <FormattedLink
+            title={t("learnMore")}
+            href={helpUrls.orgMembersUrl}
+            isInline
+          />
+        </Text>
+      </TextContent>
       {addMembersVisibility && (
         <AddMember
           refresh={refresh}
@@ -90,14 +101,15 @@ export default function OrgMembers({
           orgRoles={orgRoles}
         />
       )}
-      {viewUserOrganizationAttributes && typeof viewUserOrganizationAttributes === "object" && (
-        <ViewOrganizationUserAttributes
-          userId={viewUserOrganizationAttributes.id}
-          handleModalToggle={() => setViewUserOrganizationAttributes(false)}
-          refresh={refresh}
-          orgId={org.id}
-        />
-      )}
+      {viewUserOrganizationAttributes &&
+        typeof viewUserOrganizationAttributes === "object" && (
+          <ViewOrganizationUserAttributes
+            userId={viewUserOrganizationAttributes.id}
+            handleModalToggle={() => setViewUserOrganizationAttributes(false)}
+            refresh={refresh}
+            orgId={org.id}
+          />
+        )}
       <KeycloakDataTable
         data-testid="members-org-table"
         isPaginated

--- a/js/apps/admin-ui/src/phaseII/orgs/OrgRoles.tsx
+++ b/js/apps/admin-ui/src/phaseII/orgs/OrgRoles.tsx
@@ -3,8 +3,12 @@ import {
   AlertVariant,
   Badge,
   Button,
+  TextContent,
+  Text,
   ToolbarItem,
 } from "@patternfly/react-core";
+import { FormattedLink } from "../../components/external-link/FormattedLink";
+import helpUrls from "../../help-urls";
 
 import type { OrgRepresentation } from "./routes";
 import { KeycloakDataTable } from "@keycloak/keycloak-ui-shared";
@@ -98,6 +102,15 @@ export default function OrgRoles({ org, refresh: orgRefresh }: OrgRolesProps) {
 
   return (
     <>
+      <TextContent className="pf-v5-u-px-lg pf-v5-u-pt-lg">
+        <Text>
+          <FormattedLink
+            title={t("learnMore")}
+            href={helpUrls.orgRolesUrl}
+            isInline
+          />
+        </Text>
+      </TextContent>
       <KeycloakDataTable
         data-testid="roles-org-table"
         key={`${org.id}${key}`}

--- a/js/apps/admin-ui/src/phaseII/orgs/OrgSettings.tsx
+++ b/js/apps/admin-ui/src/phaseII/orgs/OrgSettings.tsx
@@ -15,6 +15,8 @@ import useOrgFetcher from "./useOrgFetcher";
 import { useRealm } from "../../context/realm-context/RealmContext";
 import { useTranslation } from "react-i18next";
 import { useAlerts } from "@keycloak/keycloak-ui-shared";
+import { FormattedLink } from "../../components/external-link/FormattedLink";
+import helpUrls from "../../help-urls";
 
 type OrgSettingsProps = {
   org: OrgRepresentation;
@@ -75,6 +77,13 @@ export default function OrgSettings({ org, refresh }: OrgSettingsProps) {
   return (
     <Grid hasGutter className="pf-v5-u-px-lg pf-v5-u-mt-xl">
       <GridItem span={8}>
+        <div className="pf-v5-u-mb-md">
+          <FormattedLink
+            title={t("learnMore")}
+            href={helpUrls.orgDomainsUrl}
+            isInline
+          />
+        </div>
         <FormProvider {...organizationForm}>
           <Form
             isHorizontal

--- a/js/apps/admin-ui/src/phaseII/orgs/OrgsSection.tsx
+++ b/js/apps/admin-ui/src/phaseII/orgs/OrgsSection.tsx
@@ -1,6 +1,8 @@
 import { useState } from "react";
 import {
   PageSection,
+  Text,
+  TextContent,
   ToolbarItem,
   Button,
   AlertVariant,
@@ -8,6 +10,7 @@ import {
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 import { ViewHeader } from "../../components/view-header/ViewHeader";
+import { FormattedLink } from "../../components/external-link/FormattedLink";
 import helpUrls from "../../help-urls";
 import useOrgFetcher from "./useOrgFetcher";
 import { KeycloakDataTable } from "@keycloak/keycloak-ui-shared";
@@ -71,6 +74,25 @@ export default function OrgsSection() {
         subKey={t("orgExplain")}
         helpUrl={helpUrls.orgsUrl}
       />
+      <PageSection variant="light" className="pf-v5-u-pt-0 pf-v5-u-pb-md">
+        <TextContent>
+          <Text component="small">
+            Use the{" "}
+            <FormattedLink
+              title="IdP Wizard"
+              href={helpUrls.idpWizardUrl}
+              isInline
+            />{" "}
+            to allow for self-setup for SSO configuration. Use the{" "}
+            <FormattedLink
+              title="Org Admin Portal"
+              href={helpUrls.adminPortalUrl}
+              isInline
+            />{" "}
+            to allow self-management of organizations by the members.
+          </Text>
+        </TextContent>
+      </PageSection>
       {manageOrgSettingsDialog && (
         <ManageOrgSettingsDialog
           onClose={() => {

--- a/js/apps/admin-ui/src/phaseII/orgs/routes/Org.tsx
+++ b/js/apps/admin-ui/src/phaseII/orgs/routes/Org.tsx
@@ -6,6 +6,7 @@ import { Path } from "react-router-dom";
 
 export type OrgTab =
   | "settings"
+  | "domains"
   | "attributes"
   | "members"
   | "invitations"

--- a/js/apps/admin-ui/src/phaseII/orgs/useOrgFetcher.ts
+++ b/js/apps/admin-ui/src/phaseII/orgs/useOrgFetcher.ts
@@ -21,6 +21,14 @@ export type PhaseTwoOrganizationMemberAttributesRepresentation = Record<
   string[]
 >;
 
+export type OrganizationDomainRepresentation = {
+  domain_name: string;
+  verified: boolean;
+  record_key: string;
+  record_value: string;
+  type: string;
+};
+
 type OrgResp = Response & { error: string; data?: any[] };
 
 export default function useOrgFetcher(realm: string) {
@@ -180,7 +188,7 @@ export default function useOrgFetcher(realm: string) {
     { first, max, search }: OrgMemberOptions = {
       first: 1,
       max: 100,
-    }
+    },
   ): Promise<PhaseTwoOrganizationUserRepresentation[]> {
     let query = `first=${first}&max=${max}`;
     query = search ? `${query}&search=${search}` : query;
@@ -209,10 +217,10 @@ export default function useOrgFetcher(realm: string) {
 
   async function getUserAttributesForOrgMember(
     orgId: string,
-    userId: string
+    userId: string,
   ): Promise<PhaseTwoOrganizationMemberAttributesRepresentation> {
     const resp = await fetchGet(
-      `${baseUrl}/orgs/${orgId}/members/${userId}/attributes`
+      `${baseUrl}/orgs/${orgId}/members/${userId}/attributes`,
     );
     return await resp.json();
   }
@@ -220,7 +228,7 @@ export default function useOrgFetcher(realm: string) {
   async function updateAttributesForOrgMember(
     orgId: string,
     userId: string,
-    attributes: Record<string, string[]>
+    attributes: Record<string, string[]>,
   ) {
     const token = await adminClient.getAccessToken();
     await fetch(`${baseUrl}/orgs/${orgId}/members/${userId}/attributes`, {
@@ -246,7 +254,7 @@ export default function useOrgFetcher(realm: string) {
     orgId: string,
     email: string,
     send: boolean,
-    redirectUri: string
+    redirectUri: string,
   ) {
     const token = await adminClient.getAccessToken();
     await fetch(`${baseUrl}/orgs/${orgId}/invitations`, {
@@ -289,7 +297,7 @@ export default function useOrgFetcher(realm: string) {
 
     const resp = await fetchPostRaw(
       `${baseUrl}/orgs/${orgId}/portal-link`,
-      body
+      body,
     );
 
     return await resp.json();
@@ -297,7 +305,7 @@ export default function useOrgFetcher(realm: string) {
 
   async function deleteRoleFromOrg(orgId: string, role: RoleRepresentation) {
     let resp = (await fetchDelete(
-      `${baseUrl}/orgs/${orgId}/roles/${role.name}`
+      `${baseUrl}/orgs/${orgId}/roles/${role.name}`,
     )) as OrgResp;
     if (resp.ok) {
       return {
@@ -336,11 +344,11 @@ export default function useOrgFetcher(realm: string) {
 
   async function updateRoleForOrg(
     orgId: string,
-    role: { name: string; description?: string }
+    role: { name: string; description?: string },
   ) {
     let resp = (await fetchPut(
       `${baseUrl}/orgs/${orgId}/roles/${role.name}`,
-      role
+      role,
     )) as OrgResp;
     if (resp.ok) {
       return {
@@ -360,10 +368,10 @@ export default function useOrgFetcher(realm: string) {
   async function checkOrgRoleForUser(
     orgId: string,
     role: RoleRepresentation,
-    user: UserRepresentation
+    user: UserRepresentation,
   ) {
     let resp = (await fetchGet(
-      `${baseUrl}/orgs/${orgId}/roles/${role.name}/users/${user.id}`
+      `${baseUrl}/orgs/${orgId}/roles/${role.name}/users/${user.id}`,
     )) as OrgResp;
 
     if (resp.ok) {
@@ -383,7 +391,7 @@ export default function useOrgFetcher(realm: string) {
   // GET /:realm/users/:userId/orgs/:orgId/roles
   async function listOrgRolesForUser(orgId: string, user: UserRepresentation) {
     const resp = (await fetchGet(
-      `${baseUrl}/users/${user.id}/orgs/${orgId}/roles`
+      `${baseUrl}/users/${user.id}/orgs/${orgId}/roles`,
     )) as OrgResp;
 
     if (resp.ok) {
@@ -403,11 +411,11 @@ export default function useOrgFetcher(realm: string) {
   async function setOrgRoleForUser(
     orgId: string,
     role: RoleRepresentation,
-    user: UserRepresentation
+    user: UserRepresentation,
   ) {
     let resp = (await fetchPut(
       `${baseUrl}/orgs/${orgId}/roles/${role.name}/users/${user.id}`,
-      {}
+      {},
     )) as OrgResp;
 
     if (resp.ok) {
@@ -428,10 +436,10 @@ export default function useOrgFetcher(realm: string) {
   async function revokeOrgRoleForUser(
     orgId: string,
     role: RoleRepresentation,
-    user: UserRepresentation
+    user: UserRepresentation,
   ) {
     let resp = (await fetchDelete(
-      `${baseUrl}/orgs/${orgId}/roles/${role.name}/users/${user.id}`
+      `${baseUrl}/orgs/${orgId}/roles/${role.name}/users/${user.id}`,
     )) as OrgResp;
 
     if (resp.ok) {
@@ -451,7 +459,7 @@ export default function useOrgFetcher(realm: string) {
   // PUT /:realm/identity-provider/instances/:alias
   async function updateIdentityProvider(
     idp: IdentityProviderRepresentation,
-    alias: string
+    alias: string,
   ) {
     try {
       await adminClient.identityProviders.update({ alias }, { ...idp });
@@ -501,7 +509,7 @@ export default function useOrgFetcher(realm: string) {
         query = `${query}&search=${search}`;
       }
       const resp = await fetchGet(
-        `${adminUrl}/identity-provider/instances?${query}`
+        `${adminUrl}/identity-provider/instances?${query}`,
       );
       if (resp.ok) {
         return (await resp.json()) as IdentityProviderRepresentation[];
@@ -525,12 +533,12 @@ export default function useOrgFetcher(realm: string) {
       alias: IdentityProviderRepresentation["alias"];
       post_broker_flow?: IdentityProviderRepresentation["postBrokerLoginFlowAlias"];
       sync_mode?: SyncMode;
-    }
+    },
   ) {
     try {
       const resp = await fetchPost(
         `${baseUrl}/orgs/${orgId}/idps/link`,
-        idpInformation
+        idpInformation,
       );
       if (!resp.ok) {
         throw new Error("Failed to link IDP to org.");
@@ -558,12 +566,12 @@ export default function useOrgFetcher(realm: string) {
   // POST /:realm/orgs/:orgId/idps/unlink
   async function unlinkIDPtoOrg(
     orgId: OrgRepresentation["id"],
-    idpAlias: IdentityProviderRepresentation["alias"]
+    idpAlias: IdentityProviderRepresentation["alias"],
   ) {
     try {
       const resp = await fetchPost(
         `${baseUrl}/orgs/${orgId}/idps/${idpAlias}/unlink`,
-        {}
+        {},
       );
       if (!resp.ok) {
         throw new Error("Failed to unlink Identity Provider.");
@@ -580,6 +588,45 @@ export default function useOrgFetcher(realm: string) {
         message: error,
       };
     }
+  }
+
+  // GET /:realm/orgs/:orgId/domains
+  async function getOrgDomains(
+    orgId: string,
+  ): Promise<OrganizationDomainRepresentation[]> {
+    const resp = await fetchGet(`${baseUrl}/orgs/${orgId}/domains`);
+    if (resp.ok) {
+      return await resp.json();
+    }
+    return [];
+  }
+
+  // GET /:realm/orgs/:orgId/domains/:domainName
+  async function getOrgDomain(
+    orgId: string,
+    domainName: string,
+  ): Promise<OrganizationDomainRepresentation | null> {
+    const resp = await fetchGet(
+      `${baseUrl}/orgs/${orgId}/domains/${encodeURIComponent(domainName)}`,
+    );
+    if (resp.ok) {
+      return await resp.json();
+    }
+    return null;
+  }
+
+  // POST /:realm/orgs/:orgId/domains/:domainName/verify
+  async function verifyDomain(orgId: string, domainName: string) {
+    const resp = await fetchPost(
+      `${baseUrl}/orgs/${orgId}/domains/${encodeURIComponent(
+        domainName,
+      )}/verify`,
+      {},
+    );
+    if (resp.ok) {
+      return { success: true, message: "Domain verification triggered." };
+    }
+    return { error: true, message: await resp.text() };
   }
 
   // GET /:realm/orgs/config
@@ -632,6 +679,8 @@ export default function useOrgFetcher(realm: string) {
     getIdpsForOrg,
     getIdpsForRealm,
     getOrg,
+    getOrgDomain,
+    getOrgDomains,
     getOrgInvitations,
     getOrgMembers,
     getOrgsConfig,
@@ -653,5 +702,6 @@ export default function useOrgFetcher(realm: string) {
     updateOrg,
     updateOrgsConfig,
     updateRoleForOrg,
+    verifyDomain,
   };
 }

--- a/js/apps/admin-ui/src/phaseII/realm-settings/RealmSettingsAttributesTab.tsx
+++ b/js/apps/admin-ui/src/phaseII/realm-settings/RealmSettingsAttributesTab.tsx
@@ -9,6 +9,8 @@ import {
 } from "@patternfly/react-core";
 
 import { useAlerts } from "@keycloak/keycloak-ui-shared";
+import { FormattedLink } from "../../components/external-link/FormattedLink";
+import helpUrls from "../../help-urls";
 
 import {
   AttributeForm,
@@ -78,7 +80,12 @@ export const RealmSettingsAttributeTab = ({
       >
         <p>
           This may override configuration changes elsewhere and cause unexpected
-          behavior. Use this only if you are sure what you are doing.
+          behavior. Use this only if you are sure what you are doing.{" "}
+          <FormattedLink
+            title={t("learn more")}
+            href={helpUrls.realmAttributesUrl}
+            isInline
+          />
         </p>
       </Alert>
       <div className="pf-v5-u-mb-lg pf-v5-u-w-75-on-md">


### PR DESCRIPTION
## Summary
Addresses [issue #106](https://github.com/p2-inc/dashboard-v2/issues/106) — Various admin UI improvements for Phase Two extensions.

## Changes
Help links & documentation

* Added "Learn more" link to Realm Settings > Attributes tab pointing to realm attributes docs
* Added help links to all Organization detail tabs: Settings, Attributes, Members, Invitations, Roles, Identity Providers
* Added info alert to Styles > Login instructing about attributes.v2 theme activation
* Added info alert to Styles > Portal with link to admin portal docs and instructions about launching the admin portal client

Organizations page

* Added descriptive text with links to [IdP Wizard](https://phasetwo.io/docs/organizations/idp-wizard/) and [Org Admin Portal](https://phasetwo.io/docs/admin-portal/) docs

Organization details

* Moved "Generate Portal Link" from the Action dropdown to a secondary button directly under the org name
* Added new Domains tab with domain verification UI showing:
* Domain name and verification status
* DNS TXT record value with clipboard copy for unverified domains
* Verify button to trigger domain verification
* Added domain API methods to useOrgFetcher: getOrgDomains, getOrgDomain, verifyDomain